### PR TITLE
feat: add unsaved changes warning on back navigation

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -125,6 +125,17 @@ The detail view shows:
 4. Tap **Save** to confirm
 5. Tap **Cancel** to discard changes
 
+### Unsaved Changes Warning
+
+If you try to navigate away (back button or gesture) while you have unsaved changes, the app will show a confirmation dialog:
+
+- **Keep Editing** - Stay on the screen and continue editing
+- **Discard** - Lose your changes and navigate away
+
+This warning appears when:
+- **Adding items** - Any field has content (name, description, category, images, tags, or metadata)
+- **Editing items** - Any field differs from the original saved values
+
 ---
 
 ## Deleting Items

--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react';
+import { Alert } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+/**
+ * Hook to show a confirmation dialog when user tries to navigate away with unsaved changes.
+ * Works with both hardware back button and gesture navigation.
+ * 
+ * @param hasUnsavedChanges - Whether there are unsaved changes to warn about
+ * @param message - Optional custom message for the alert
+ */
+export function useUnsavedChangesWarning(
+  hasUnsavedChanges: boolean,
+  message: string = 'You have unsaved changes. Are you sure you want to discard them?'
+) {
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    if (!hasUnsavedChanges) return;
+
+    const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      // Prevent default behavior of leaving the screen
+      e.preventDefault();
+
+      // Show confirmation dialog
+      Alert.alert(
+        'Discard Changes?',
+        message,
+        [
+          {
+            text: 'Keep Editing',
+            style: 'cancel',
+            onPress: () => {},
+          },
+          {
+            text: 'Discard',
+            style: 'destructive',
+            onPress: () => navigation.dispatch(e.data.action),
+          },
+        ]
+      );
+    });
+
+    return unsubscribe;
+  }, [hasUnsavedChanges, message, navigation]);
+}

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import {
   Alert,
   View,
@@ -25,6 +25,7 @@ import StyledInput from '../../components/StyledInput';
 import MetadataInput from '../../components/MetadataInput';
 import StyledButton from '../../components/StyledButton';
 import { createStyles } from './styles';
+import { useUnsavedChangesWarning } from '../../hooks/useUnsavedChangesWarning';
 
 type AddItemScreenNavigationProp = NativeStackNavigationProp<
   RootStackParamList,
@@ -54,6 +55,21 @@ export default function AddItemScreen() {
   const [isTagInputFocused, setIsTagInputFocused] = useState(false);
 
   const navigation = useNavigation<AddItemScreenNavigationProp>();
+
+  // Detect if form has unsaved changes
+  const hasUnsavedChanges = useMemo(() => {
+    if (name.trim() !== '') return true;
+    if (description.trim() !== '') return true;
+    if (category !== '') return true;
+    if (images.length > 0) return true;
+    if (tags.length > 0) return true;
+    // Check if any metadata has non-empty values
+    if (metadata.some(m => m.value.trim() !== '')) return true;
+    return false;
+  }, [name, description, category, images, tags, metadata]);
+
+  // Show warning when navigating away with unsaved changes
+  useUnsavedChangesWarning(hasUnsavedChanges);
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);

--- a/src/screens/ItemDetailsScreen/index.tsx
+++ b/src/screens/ItemDetailsScreen/index.tsx
@@ -1,6 +1,6 @@
 // src/screens/ItemDetailsScreen/index.tsx
 
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useMemo } from 'react';
 import {
   View,
   Text,
@@ -31,6 +31,7 @@ import StyledInput from '../../components/StyledInput';
 import MetadataInput from '../../components/MetadataInput';
 import StyledButton from '../../components/StyledButton';
 import { createStyles } from './styles';
+import { useUnsavedChangesWarning } from '../../hooks/useUnsavedChangesWarning';
 
 type ItemDetailsRouteProp = RouteProp<RootStackParamList, 'ItemDetails'>;
 type ItemDetailsNavigationProp = NativeStackNavigationProp<
@@ -72,6 +73,40 @@ export default function ItemDetailsScreen() {
   // TODO?: Offload to SQL query with WHERE
   const { items, updateItemOptimistic, deleteItemOptimistic } =
     useDatabase();
+
+  // Detect if form has unsaved changes (only when editing)
+  const hasUnsavedChanges = useMemo(() => {
+    if (!isEditing || !item) return false;
+    
+    // Compare current form state with original item
+    if (name !== item.name) return true;
+    if (description !== item.description) return true;
+    if (category !== item.category) return true;
+    
+    // Compare tags
+    const originalTags = [...(item.tags || [])].sort().join(',');
+    const currentTags = [...tags].sort().join(',');
+    if (originalTags !== currentTags) return true;
+    
+    // Compare images
+    const originalImages = [...(item.images || [])].sort().join(',');
+    const currentImages = [...images].sort().join(',');
+    if (originalImages !== currentImages) return true;
+    
+    // Compare metadata
+    const originalMeta = JSON.stringify(
+      Object.entries(item.metadata || {}).sort(([a], [b]) => a.localeCompare(b))
+    );
+    const currentMeta = JSON.stringify(
+      metadata.filter(m => m.key).map(m => [m.key, m.value]).sort(([a], [b]) => a.localeCompare(b))
+    );
+    if (originalMeta !== currentMeta) return true;
+    
+    return false;
+  }, [isEditing, item, name, description, category, tags, images, metadata]);
+
+  // Show warning when navigating away with unsaved changes
+  useUnsavedChangesWarning(hasUnsavedChanges);
 
   function populateFromItem(selected: WardrobeItem) {
     setItem(selected);


### PR DESCRIPTION
## Summary
Adds a confirmation dialog when users try to navigate away from forms with unsaved changes.

## Changes
- Create `useUnsavedChangesWarning` hook using React Navigation's `beforeRemove` listener
- AddItemScreen: warns when any field has content
- ItemDetailsScreen: warns when in edit mode with changes from original
- Updated USER_GUIDE.md with documentation

## How it works
- Dialog shows "Discard Changes?" with options:
   - **Keep Editing** - Stay on screen
   - **Discard** - Navigate away and lose changes
- Works with hardware back button and gesture navigation