### PR TITLE
fix: unsaved changes warning now works with Cancel buttons/gestures

### DIFF
--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,13 +1,14 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 /**
  * Hook to show a confirmation dialog when user tries to navigate away with unsaved changes.
- * Works with both hardware back button and gesture navigation.
+ * Works with hardware back button, gesture navigation, and Cancel buttons.
  * 
  * @param hasUnsavedChanges - Whether there are unsaved changes to warn about
  * @param message - Optional custom message for the alert
+ * @returns Object with showWarningIfNeeded helper function
  */
 export function useUnsavedChangesWarning(
   hasUnsavedChanges: boolean,
@@ -15,6 +16,7 @@ export function useUnsavedChangesWarning(
 ) {
   const navigation = useNavigation();
 
+  // Handle back button and gesture navigation
   useEffect(() => {
     if (!hasUnsavedChanges) return;
 
@@ -43,4 +45,36 @@ export function useUnsavedChangesWarning(
 
     return unsubscribe;
   }, [hasUnsavedChanges, message, navigation]);
+
+  /**
+   * Helper function to show warning before executing an action.
+   * Use this for Cancel buttons or any action that should warn about unsaved changes.
+   * 
+   * @param onDiscard - Callback to execute if user chooses to discard changes
+   */
+  const showWarningIfNeeded = useCallback((onDiscard: () => void) => {
+    if (!hasUnsavedChanges) {
+      onDiscard();
+      return;
+    }
+
+    Alert.alert(
+      'Discard Changes?',
+      message,
+      [
+        {
+          text: 'Keep Editing',
+          style: 'cancel',
+          onPress: () => {},
+        },
+        {
+          text: 'Discard',
+          style: 'destructive',
+          onPress: onDiscard,
+        },
+      ]
+    );
+  }, [hasUnsavedChanges, message]);
+
+  return { showWarningIfNeeded };
 }

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -69,7 +69,7 @@ export default function AddItemScreen() {
   }, [name, description, category, images, tags, metadata]);
 
   // Show warning when navigating away with unsaved changes
-  useUnsavedChangesWarning(hasUnsavedChanges);
+  const { showWarningIfNeeded } = useUnsavedChangesWarning(hasUnsavedChanges);
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);
@@ -248,7 +248,7 @@ export default function AddItemScreen() {
               title="Cancel"
               icon="close-circle-outline"
               variant="secondary"
-              onPress={() => navigation.goBack()}
+              onPress={() => showWarningIfNeeded(() => navigation.goBack())}
             />
             <StyledButton
               title="Save Item"

--- a/src/screens/ItemDetailsScreen/index.tsx
+++ b/src/screens/ItemDetailsScreen/index.tsx
@@ -106,7 +106,7 @@ export default function ItemDetailsScreen() {
   }, [isEditing, item, name, description, category, tags, images, metadata]);
 
   // Show warning when navigating away with unsaved changes
-  useUnsavedChangesWarning(hasUnsavedChanges);
+  const { showWarningIfNeeded } = useUnsavedChangesWarning(hasUnsavedChanges);
 
   function populateFromItem(selected: WardrobeItem) {
     setItem(selected);
@@ -471,10 +471,10 @@ export default function ItemDetailsScreen() {
                   title="Cancel"
                   icon="close-circle-outline"
                   variant="secondary"
-                  onPress={() => {
+                  onPress={() => showWarningIfNeeded(() => {
                     setIsEditing(false);
                     if (item) populateFromItem(item);
-                  }}
+                  })}
                 />
                 <StyledButton
                   title="Save"


### PR DESCRIPTION
## Summary
Fixes the unsaved changes warning to work with Cancel buttons, not just back navigation.

## Changes
- `useUnsavedChangesWarning` hook now returns `showWarningIfNeeded` helper function
- AddItemScreen Cancel button uses the helper
- ItemDetailsScreen Cancel button uses the helper
- Back button and gesture navigation still handled by `beforeRemove` listener

## Testing
- [x] Add Item → type something → tap Cancel → shows warning
- [x] Add Item → type something → back button → shows warning
- [x] Edit Item → change something → tap Cancel → shows warning
- [x] Edit Item → change something → back button → shows warning