### PR TITLE
Fix: Unsaved Changes Warning Consistent Behavior

### DIFF
--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, MutableRefObject } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
@@ -7,18 +7,34 @@ import { useNavigation } from '@react-navigation/native';
  * Works with back button, gestures, and programmatic navigation.
  * 
  * @param hasUnsavedChanges - Whether there are unsaved changes to warn about
- * @param message - Optional custom message for the alert
+ * @param options - Optional config: message and skipRef to bypass warning
  */
 export function useUnsavedChangesWarning(
   hasUnsavedChanges: boolean,
-  message: string = 'You have unsaved changes. Are you sure you want to discard them?'
+  options?: {
+    message?: string;
+    skipRef?: MutableRefObject<boolean>;
+  }
 ) {
   const navigation = useNavigation();
+  const message = options?.message ?? 'You have unsaved changes. Are you sure you want to discard them?';
+  const skipRef = options?.skipRef;
+  const hasUnsavedRef = useRef(hasUnsavedChanges);
+  
+  // Keep ref in sync with prop
+  useEffect(() => {
+    hasUnsavedRef.current = hasUnsavedChanges;
+  }, [hasUnsavedChanges]);
 
   useEffect(() => {
-    if (!hasUnsavedChanges) return;
-
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      // Check refs at event time, not at setup time
+      if (!hasUnsavedRef.current) return;
+      if (skipRef?.current) {
+        skipRef.current = false;
+        return;
+      }
+
       e.preventDefault();
 
       Alert.alert(
@@ -36,5 +52,5 @@ export function useUnsavedChangesWarning(
     });
 
     return unsubscribe;
-  }, [hasUnsavedChanges, message, navigation]);
+  }, [message, navigation, skipRef]);
 }

--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,50 +1,31 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useEffect } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 /**
  * Hook to show a confirmation dialog when user tries to navigate away with unsaved changes.
- * Works with both hardware back button and gesture navigation.
+ * Works with back button, gestures, and programmatic navigation.
  * 
  * @param hasUnsavedChanges - Whether there are unsaved changes to warn about
  * @param message - Optional custom message for the alert
- * @returns Object with skipWarningOnce function to bypass warning for intentional navigation (e.g., after save)
  */
 export function useUnsavedChangesWarning(
   hasUnsavedChanges: boolean,
   message: string = 'You have unsaved changes. Are you sure you want to discard them?'
 ) {
   const navigation = useNavigation();
-  const skipNextWarning = useRef(false);
-
-  // Call this before navigation.goBack() when saving successfully
-  const skipWarningOnce = useCallback(() => {
-    skipNextWarning.current = true;
-  }, []);
 
   useEffect(() => {
     if (!hasUnsavedChanges) return;
 
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      // Skip warning if intentionally navigating (e.g., after save)
-      if (skipNextWarning.current) {
-        skipNextWarning.current = false;
-        return;
-      }
-
-      // Prevent default behavior of leaving the screen
       e.preventDefault();
 
-      // Show confirmation dialog
       Alert.alert(
         'Discard Changes?',
         message,
         [
-          {
-            text: 'Keep Editing',
-            style: 'cancel',
-            onPress: () => {},
-          },
+          { text: 'Keep Editing', style: 'cancel' },
           {
             text: 'Discard',
             style: 'destructive',
@@ -56,6 +37,4 @@ export function useUnsavedChangesWarning(
 
     return unsubscribe;
   }, [hasUnsavedChanges, message, navigation]);
-
-  return { skipWarningOnce };
 }

--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
@@ -8,17 +8,30 @@ import { useNavigation } from '@react-navigation/native';
  * 
  * @param hasUnsavedChanges - Whether there are unsaved changes to warn about
  * @param message - Optional custom message for the alert
+ * @returns Object with skipWarningOnce function to bypass warning for intentional navigation (e.g., after save)
  */
 export function useUnsavedChangesWarning(
   hasUnsavedChanges: boolean,
   message: string = 'You have unsaved changes. Are you sure you want to discard them?'
 ) {
   const navigation = useNavigation();
+  const skipNextWarning = useRef(false);
+
+  // Call this before navigation.goBack() when saving successfully
+  const skipWarningOnce = useCallback(() => {
+    skipNextWarning.current = true;
+  }, []);
 
   useEffect(() => {
     if (!hasUnsavedChanges) return;
 
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
+      // Skip warning if intentionally navigating (e.g., after save)
+      if (skipNextWarning.current) {
+        skipNextWarning.current = false;
+        return;
+      }
+
       // Prevent default behavior of leaving the screen
       e.preventDefault();
 
@@ -43,4 +56,6 @@ export function useUnsavedChangesWarning(
 
     return unsubscribe;
   }, [hasUnsavedChanges, message, navigation]);
+
+  return { skipWarningOnce };
 }

--- a/src/hooks/useUnsavedChangesWarning.ts
+++ b/src/hooks/useUnsavedChangesWarning.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, MutableRefObject } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
@@ -7,31 +7,33 @@ import { useNavigation } from '@react-navigation/native';
  * Works with back button, gestures, and programmatic navigation.
  * 
  * @param hasUnsavedChanges - Whether there are unsaved changes to warn about
- * @param options - Optional config: message and skipRef to bypass warning
+ * @param message - Optional custom message for the alert
+ * @returns Object with skipWarningOnce function to bypass warning (call before goBack after save)
  */
 export function useUnsavedChangesWarning(
   hasUnsavedChanges: boolean,
-  options?: {
-    message?: string;
-    skipRef?: MutableRefObject<boolean>;
-  }
+  message: string = 'You have unsaved changes. Are you sure you want to discard them?'
 ) {
   const navigation = useNavigation();
-  const message = options?.message ?? 'You have unsaved changes. Are you sure you want to discard them?';
-  const skipRef = options?.skipRef;
+  const skipNextWarning = useRef(false);
   const hasUnsavedRef = useRef(hasUnsavedChanges);
-  
-  // Keep ref in sync with prop
+
+  // Keep ref in sync with prop (refs are checked inside callback)
   useEffect(() => {
     hasUnsavedRef.current = hasUnsavedChanges;
   }, [hasUnsavedChanges]);
 
+  const skipWarningOnce = useCallback(() => {
+    skipNextWarning.current = true;
+  }, []);
+
   useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      // Check refs at event time, not at setup time
+      // Check ref at event time, not setup time
       if (!hasUnsavedRef.current) return;
-      if (skipRef?.current) {
-        skipRef.current = false;
+      
+      if (skipNextWarning.current) {
+        skipNextWarning.current = false;
         return;
       }
 
@@ -52,5 +54,7 @@ export function useUnsavedChangesWarning(
     });
 
     return unsubscribe;
-  }, [message, navigation, skipRef]);
+  }, [message, navigation]);
+
+  return { skipWarningOnce };
 }

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -107,7 +107,7 @@ export default function AddItemScreen() {
   }, [name, description, category, images, tags, metadata, isEditing, editItem]);
 
   // Show warning when navigating away with unsaved changes
-  useUnsavedChangesWarning(hasUnsavedChanges);
+  const { skipWarningOnce } = useUnsavedChangesWarning(hasUnsavedChanges);
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);
@@ -324,6 +324,9 @@ export default function AddItemScreen() {
                 const result = await handleAddItem();
 
                 if (!result) return;
+
+                // Skip unsaved changes warning since we just saved
+                skipWarningOnce();
 
                 if (isEditing) {
                   Alert.alert('Success', 'Item updated!');

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -46,9 +46,19 @@ export default function AddItemScreen() {
   const editItem = route.params?.item;
   const isEditing = !!editItem;
 
-  const [name, setName] = useState(editItem?.name || '');
-  const [description, setDescription] = useState(editItem?.description || '');
-  const [category, setCategory] = useState(editItem?.category || '');
+  // Track "saved" state to compare against for unsaved changes detection
+  const [savedState, setSavedState] = useState({
+    name: editItem?.name || '',
+    description: editItem?.description || '',
+    category: editItem?.category || '',
+    tags: editItem?.tags || [],
+    images: editItem?.images || [],
+    metadata: editItem?.metadata || {},
+  });
+
+  const [name, setName] = useState(savedState.name);
+  const [description, setDescription] = useState(savedState.description);
+  const [category, setCategory] = useState(savedState.category);
 
   // Transform metadata object to array for editing, or use defaults
   const initialMetadata = useMemo(() => {
@@ -76,38 +86,29 @@ export default function AddItemScreen() {
   }, [editItem]);
 
   const [metadata, setMetadata] = useState<{ key: string; value: string }[]>(initialMetadata);
-  const [tags, setTags] = useState<string[]>(editItem?.tags || []);
-  const [images, setImages] = useState<string[]>(editItem?.images || []);
+  const [tags, setTags] = useState<string[]>(savedState.tags);
+  const [images, setImages] = useState<string[]>(savedState.images);
   const [multiAdd, setMultiAdd] = useState(false);
   const [isTagInputFocused, setIsTagInputFocused] = useState(false);
 
-  // Detect if form has unsaved changes
+  // Detect if form has unsaved changes by comparing to saved state
   const hasUnsavedChanges = useMemo(() => {
-    if (isEditing) {
-      if (name !== editItem.name) return true;
-      if (description !== editItem.description) return true;
-      if (category !== editItem.category) return true;
-      if (JSON.stringify(tags) !== JSON.stringify(editItem.tags)) return true;
-      if (JSON.stringify(images) !== JSON.stringify(editItem.images)) return true;
-      // Metadata check
-      const currentMetaObj = Object.fromEntries(
-        metadata.filter(m => m.key && m.value.trim() !== '').map(m => [m.key, m.value])
-      );
-      if (JSON.stringify(currentMetaObj) !== JSON.stringify(editItem.metadata)) return true;
-      return false;
-    }
-
-    if (name.trim() !== '') return true;
-    if (description.trim() !== '') return true;
-    if (category !== '') return true;
-    if (images.length > 0) return true;
-    if (tags.length > 0) return true;
-    if (metadata.some(m => m.value.trim() !== '')) return true;
+    if (name !== savedState.name) return true;
+    if (description !== savedState.description) return true;
+    if (category !== savedState.category) return true;
+    if (JSON.stringify(tags) !== JSON.stringify(savedState.tags)) return true;
+    if (JSON.stringify(images) !== JSON.stringify(savedState.images)) return true;
+    
+    const currentMetaObj = Object.fromEntries(
+      metadata.filter(m => m.key && m.value.trim() !== '').map(m => [m.key, m.value])
+    );
+    if (JSON.stringify(currentMetaObj) !== JSON.stringify(savedState.metadata)) return true;
+    
     return false;
-  }, [name, description, category, images, tags, metadata, isEditing, editItem]);
+  }, [name, description, category, images, tags, metadata, savedState]);
 
   // Show warning when navigating away with unsaved changes
-  const { skipWarningOnce } = useUnsavedChangesWarning(hasUnsavedChanges);
+  useUnsavedChangesWarning(hasUnsavedChanges);
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);
@@ -181,7 +182,17 @@ export default function AddItemScreen() {
             images: savedImageUris,
           });
 
-          if (!multiAdd) {
+          if (multiAdd) {
+            // Reset form for next item
+            const emptyState = {
+              name: '',
+              description: '',
+              category: '',
+              tags: [],
+              images: [],
+              metadata: {},
+            };
+            setSavedState(emptyState);
             setName('');
             setDescription('');
             setCategory('');
@@ -195,6 +206,16 @@ export default function AddItemScreen() {
             setImages([]);
           }
         }
+        
+        // Update saved state so hasUnsavedChanges becomes false
+        setSavedState({
+          name,
+          description,
+          category,
+          tags: tagArr,
+          images: savedImageUris,
+          metadata: metaObj,
+        });
       } catch (err) {
         console.error(err);
         Alert.alert('Error', `Failed to ${isEditing ? 'update' : 'add'} item`);
@@ -324,9 +345,6 @@ export default function AddItemScreen() {
                 const result = await handleAddItem();
 
                 if (!result) return;
-
-                // Skip unsaved changes warning since we just saved
-                skipWarningOnce();
 
                 if (isEditing) {
                   Alert.alert('Success', 'Item updated!');

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo } from 'react';
+import React, { useState, useRef, useMemo, useCallback } from 'react';
 import {
   Alert,
   View,
@@ -90,6 +90,7 @@ export default function AddItemScreen() {
   const [images, setImages] = useState<string[]>(savedState.images);
   const [multiAdd, setMultiAdd] = useState(false);
   const [isTagInputFocused, setIsTagInputFocused] = useState(false);
+  const justSavedRef = useRef(false);
 
   // Detect if form has unsaved changes by comparing to saved state
   const hasUnsavedChanges = useMemo(() => {
@@ -107,8 +108,8 @@ export default function AddItemScreen() {
     return false;
   }, [name, description, category, images, tags, metadata, savedState]);
 
-  // Show warning when navigating away with unsaved changes
-  useUnsavedChangesWarning(hasUnsavedChanges);
+  // Show warning when navigating away with unsaved changes (skip if just saved)
+  useUnsavedChangesWarning(hasUnsavedChanges && !justSavedRef.current);
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);
@@ -346,6 +347,9 @@ export default function AddItemScreen() {
 
                 if (!result) return;
 
+                // Mark as just saved so warning doesn't show
+                justSavedRef.current = true;
+
                 if (isEditing) {
                   Alert.alert('Success', 'Item updated!');
                   navigation.goBack();
@@ -357,6 +361,9 @@ export default function AddItemScreen() {
                   navigation.goBack();
                   return;
                 }
+
+                // Reset for next item in multi-add mode
+                justSavedRef.current = false;
 
                 Toast.show({
                   type: 'success',

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useMemo, useCallback } from 'react';
+import React, { useState, useRef, useMemo } from 'react';
 import {
   Alert,
   View,
@@ -90,7 +90,6 @@ export default function AddItemScreen() {
   const [images, setImages] = useState<string[]>(savedState.images);
   const [multiAdd, setMultiAdd] = useState(false);
   const [isTagInputFocused, setIsTagInputFocused] = useState(false);
-  const justSavedRef = useRef(false);
 
   // Detect if form has unsaved changes by comparing to saved state
   const hasUnsavedChanges = useMemo(() => {
@@ -108,8 +107,8 @@ export default function AddItemScreen() {
     return false;
   }, [name, description, category, images, tags, metadata, savedState]);
 
-  // Show warning when navigating away with unsaved changes (skip if just saved)
-  useUnsavedChangesWarning(hasUnsavedChanges, { skipRef: justSavedRef });
+  // Show warning when navigating away with unsaved changes
+  const { skipWarningOnce } = useUnsavedChangesWarning(hasUnsavedChanges);
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);
@@ -347,8 +346,8 @@ export default function AddItemScreen() {
 
                 if (!result) return;
 
-                // Mark as just saved so warning doesn't show
-                justSavedRef.current = true;
+                // Skip warning since we intentionally saved
+                skipWarningOnce();
 
                 if (isEditing) {
                   Alert.alert('Success', 'Item updated!');
@@ -362,8 +361,7 @@ export default function AddItemScreen() {
                   return;
                 }
 
-                // Reset for next item in multi-add mode
-                justSavedRef.current = false;
+
 
                 Toast.show({
                   type: 'success',

--- a/src/screens/AddItemScreen/index.tsx
+++ b/src/screens/AddItemScreen/index.tsx
@@ -109,7 +109,7 @@ export default function AddItemScreen() {
   }, [name, description, category, images, tags, metadata, savedState]);
 
   // Show warning when navigating away with unsaved changes (skip if just saved)
-  useUnsavedChangesWarning(hasUnsavedChanges && !justSavedRef.current);
+  useUnsavedChangesWarning(hasUnsavedChanges, { skipRef: justSavedRef });
 
   const addMetadataField = () => {
     setMetadata([...metadata, { key: '', value: '' }]);


### PR DESCRIPTION
The unsaved changes warning was incorrectly triggering when clicking "Update Item" or "Save Item" buttons, even though the user intentionally saved their changes.

Solution

Updated useUnsavedChangesWarning hook to:
1. Use refs checked inside the beforeRemove callback (not at setup time)
2. Return a skipWarningOnce() function to bypass warning after intentional save

Changes
•  `useUnsavedChangesWarning.ts`: Added hasUnsavedRef to track state changes dynamically, returns skipWarningOnce() for intentional navigation
•  `AddItemScreen`: Calls skipWarningOnce() before goBack() after successful save

Why This Works

The original implementation checked hasUnsavedChanges when setting up the listener. Since React state updates are async, the warning would fire before the state reflected the save.
By using refs checked at event time, we get accurate state when the navigation actually occurs.

Warning Now Shows For
•  Back button
•  Swipe gesture
•  Cancel button

Warning Does NOT Show For
•  Save/Update Item button (intentional save)